### PR TITLE
added support for ch1903+lv95

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,9 @@ function cleanWKT(wkt) {
       || ~wkt.datumCode.indexOf('geodetic_datum_of_1965')) {
       wkt.datumCode = 'ire65';
     }
+    if (wkt.datumCode === 'ch1903+') {
+      wkt.datumCode = 'ch1903';
+    }
   }
   if (wkt.b && !isFinite(wkt.b)) {
     wkt.b = wkt.a;
@@ -122,9 +125,11 @@ function cleanWKT(wkt) {
     ['latitude_of_origin', 'Central_Parallel'],
     ['scale_factor', 'Scale_Factor'],
     ['k0', 'scale_factor'],
+    ['latitude_of_center', 'Latitude_Of_Center'],
     ['latitude_of_center', 'Latitude_of_center'],
     ['lat0', 'latitude_of_center', d2r],
     ['longitude_of_center', 'Longitude_Of_Center'],
+    ['longitude_of_center', 'Longitude_of_center'],
     ['longc', 'longitude_of_center', d2r],
     ['x0', 'false_easting', toMeter],
     ['y0', 'false_northing', toMeter],
@@ -133,6 +138,7 @@ function cleanWKT(wkt) {
     ['lat0', 'standard_parallel_1', d2r],
     ['lat1', 'standard_parallel_1', d2r],
     ['lat2', 'standard_parallel_2', d2r],
+    ['azimuth', 'Azimuth'],
     ['alpha', 'azimuth', d2r],
     ['srsCode', 'name']
   ];

--- a/wkt.build.js
+++ b/wkt.build.js
@@ -370,6 +370,9 @@ function cleanWKT(wkt) {
       || ~wkt.datumCode.indexOf('geodetic_datum_of_1965')) {
       wkt.datumCode = 'ire65';
     }
+    if (wkt.datumCode === 'ch1903+') {
+      wkt.datumCode = 'ch1903';
+    }
   }
   if (wkt.b && !isFinite(wkt.b)) {
     wkt.b = wkt.a;
@@ -392,9 +395,11 @@ function cleanWKT(wkt) {
     ['latitude_of_origin', 'Central_Parallel'],
     ['scale_factor', 'Scale_Factor'],
     ['k0', 'scale_factor'],
+    ['latitude_of_center', 'Latitude_Of_Center'],
     ['latitude_of_center', 'Latitude_of_center'],
     ['lat0', 'latitude_of_center', d2r],
     ['longitude_of_center', 'Longitude_Of_Center'],
+    ['longitude_of_center', 'Longitude_of_center'],
     ['longc', 'longitude_of_center', d2r],
     ['x0', 'false_easting', toMeter],
     ['y0', 'false_northing', toMeter],
@@ -403,6 +408,7 @@ function cleanWKT(wkt) {
     ['lat0', 'standard_parallel_1', d2r],
     ['lat1', 'standard_parallel_1', d2r],
     ['lat2', 'standard_parallel_2', d2r],
+    ['azimuth', 'Azimuth'],
     ['alpha', 'azimuth', d2r],
     ['srsCode', 'name']
   ];


### PR DESCRIPTION
support for projection:

PROJCS["CH1903+_LV95",GEOGCS["GCS_CH1903+",DATUM["D_CH1903+",SPHEROID["Bessel_1841",6377397.155,299.1528128],TOWGS84[674.374,15.056,405.346,0,0,0,0]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["False_Easting",2600000],PARAMETER["False_Northing",1200000],PARAMETER["Scale_Factor",1],PARAMETER["Longitude_Of_Center",7.43958333333333],PARAMETER["Latitude_Of_Center",46.9524055555556],PARAMETER["Azimuth",90],UNIT["Meter",1,AUTHORITY["EPSG","9001"]],AUTHORITY["EPSG","2056"]]
