### PR TITLE
fix js falsy values convert

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,10 +172,10 @@ function cleanWKT(wkt) {
     ['srsCode', 'name']
   ];
   list.forEach(renamer);
-  if (!wkt.long0 && wkt.longc && (wkt.projName === 'Albers_Conic_Equal_Area' || wkt.projName === 'Lambert_Azimuthal_Equal_Area')) {
+  if (!(wkt.long0 || wkt.long0 === 0) && (wkt.longc || wkt.longc === 0) && (wkt.projName === 'Albers_Conic_Equal_Area' || wkt.projName === 'Lambert_Azimuthal_Equal_Area')) {
     wkt.long0 = wkt.longc;
   }
-  if (!wkt.lat_ts && wkt.lat1 && (wkt.projName === 'Stereographic_South_Pole' || wkt.projName === 'Polar Stereographic (variant B)')) {
+  if (!(wkt.lat_ts || wkt.lat_ts === 0) && (wkt.lat1 || wkt.lat1 === 0)  && (wkt.projName === 'Stereographic_South_Pole' || wkt.projName === 'Polar Stereographic (variant B)')) {
     wkt.lat0 = d2r(wkt.lat1 > 0 ? 90 : -90);
     wkt.lat_ts = wkt.lat1;
   }

--- a/wkt.build.js
+++ b/wkt.build.js
@@ -449,10 +449,10 @@ function cleanWKT(wkt) {
     ['srsCode', 'name']
   ];
   list.forEach(renamer);
-  if (!wkt.long0 && wkt.longc && (wkt.projName === 'Albers_Conic_Equal_Area' || wkt.projName === 'Lambert_Azimuthal_Equal_Area')) {
+  if (!(wkt.long0 || wkt.long0 === 0) && (wkt.longc || wkt.longc === 0) && (wkt.projName === 'Albers_Conic_Equal_Area' || wkt.projName === 'Lambert_Azimuthal_Equal_Area')) {
     wkt.long0 = wkt.longc;
   }
-  if (!wkt.lat_ts && wkt.lat1 && (wkt.projName === 'Stereographic_South_Pole' || wkt.projName === 'Polar Stereographic (variant B)')) {
+  if (!(wkt.lat_ts || wkt.lat_ts === 0) && (wkt.lat1 || wkt.lat1 === 0)  && (wkt.projName === 'Stereographic_South_Pole' || wkt.projName === 'Polar Stereographic (variant B)')) {
     wkt.lat0 = d2r(wkt.lat1 > 0 ? 90 : -90);
     wkt.lat_ts = wkt.lat1;
   }


### PR DESCRIPTION
Hello, in some cases `long0` gets wrong value if `longc` is `0` and messes up the result of proj4js.
Here is an example:

```
// EPSG:6932
var proj4Def = '+proj=laea +lat_0=-90 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs';
// in ogc wkt 'longitude_of_center' is 0
var ogcWktDef = 'PROJCS["WGS 84 / NSIDC EASE-Grid 2.0 South",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",-90],PARAMETER["longitude_of_center",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],AUTHORITY["EPSG","6932"]]';
var esriWktDef = 'PROJCS["Lambert_Azimuthal_Equal_Area",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_origin",-90],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1]]';

var point = [17.888058560281515, 46.89226406700879];

console.log(proj4('WGS84', proj4Def, point)); // [3638523.4746012595, 11273118.062993607]
console.log(proj4('WGS84', ogcWktDef, point)); // [NaN, NaN]
console.log(proj4('WGS84', esriWktDef, point)); // [3638523.4746012595, 11273118.062993607]
```
`[NaN, NaN]` should be: `[3638523.4746012595, 11273118.062993607]`

In proj4dart we did some [bulk tests](https://github.com/maRci002/proj4dart/blob/0e3e1f08de647d493aa596a6d1b2bd82eded6477/test/proj4dart_test.dart#L137) with 8500 projdefs (from PostGIS) and this caused a little mess :smiley: