### PR TITLE
Support GEOGCRS

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function d2r(input) {
 }
 
 function cleanWKT(wkt) {
-  if (wkt.type === 'GEOGCS') {
+  if (wkt.type === 'GEOGCS' || wkt.type === 'GEOGCRS') {
     wkt.projName = 'longlat';
   } else if (wkt.type === 'LOCAL_CS') {
     wkt.projName = 'identity';
@@ -60,7 +60,7 @@ function cleanWKT(wkt) {
       wkt.units = 'meter';
     }
     if (wkt.UNIT.convert) {
-      if (wkt.type === 'GEOGCS') {
+      if (wkt.type === 'GEOGCS' || wkt.type === 'GEOGCRS') {
         if (wkt.DATUM && wkt.DATUM.SPHEROID) {
           wkt.to_meter = wkt.UNIT.convert*wkt.DATUM.SPHEROID.a;
         }
@@ -69,8 +69,8 @@ function cleanWKT(wkt) {
       }
     }
   }
-  var geogcs = wkt.GEOGCS;
-  if (wkt.type === 'GEOGCS') {
+  var geogcs = wkt.GEOGCS || wkt.GEOGCRS;
+  if (wkt.type === 'GEOGCS' || wkt.type === 'GEOGCRS') {
     geogcs = wkt;
   }
   if (geogcs) {
@@ -88,7 +88,7 @@ function cleanWKT(wkt) {
     if (wkt.datumCode === 'new_zealand_geodetic_datum_1949' || wkt.datumCode === 'new_zealand_1949') {
       wkt.datumCode = 'nzgd49';
     }
-    if (wkt.datumCode === 'wgs_1984' || wkt.datumCode === 'world_geodetic_system_1984') {
+    if (wkt.datumCode === 'wgs_1984' || wkt.datumCode === 'world_geodetic_system_1984' || wkt.datumCode === 'world geodetic system 1984') {
       if (wkt.PROJECTION === 'Mercator_Auxiliary_Sphere') {
         wkt.sphere = true;
       }

--- a/process.js
+++ b/process.js
@@ -80,6 +80,7 @@ export function sExpr(v, obj) {
     case 'PROJECTEDCRS':
     case 'PROJCRS':
     case 'GEOGCS':
+    case 'GEOGCRS':
     case 'GEOCCS':
     case 'PROJCS':
     case 'LOCAL_CS':


### PR DESCRIPTION
Attempted fix for https://github.com/proj4js/proj4js/issues/370. I don't know WKT very well, so looking forward to a review.

```js
var parser = require('./wkt.build')
var wkt = `\
GEOGCRS["WGS 84",
    DATUM["World Geodetic System 1984",
        ELLIPSOID["WGS 84",6378137,298.257223563,
            LENGTHUNIT["metre",1]]],
    PRIMEM["Greenwich",0,
        ANGLEUNIT["degree",0.0174532925199433]],
    CS[ellipsoidal,2],
        AXIS["geodetic latitude (Lat)",north,
            ORDER[1],
            ANGLEUNIT["degree",0.0174532925199433]],
        AXIS["geodetic longitude (Lon)",east,
            ORDER[2],
            ANGLEUNIT["degree",0.0174532925199433]],
    USAGE[
        SCOPE["unknown"],
        AREA["World"],
        BBOX[-90,-180,90,180]],
    ID["EPSG",4326]]
`
var out = parser(wkt)
console.log(JSON.stringify(out))
```

```json
{
  "type": "GEOGCRS",
  "name": "WGS 84",
  "DATUM": {
    "name": "World Geodetic System 1984",
    "ELLIPSOID": {
      "name": "WGS 84",
      "a": 6378137,
      "rf": 298.257223563,
      "LENGTHUNIT": { "metre": 1 }
    }
  },
  "PRIMEM": {
    "name": "greenwich",
    "convert": 0,
    "ANGLEUNIT": { "degree": 0.0174532925199433 }
  },
  "CS": { "ellipsoidal": 2 },
  "AXIS": [
    [
      "geodetic latitude (Lat)",
      "north",
      ["ORDER", 1],
      ["ANGLEUNIT", "degree", 0.0174532925199433]
    ],
    [
      "geodetic longitude (Lon)",
      "east",
      ["ORDER", 2],
      ["ANGLEUNIT", "degree", 0.0174532925199433]
    ]
  ],
  "USAGE": {
    "SCOPE": "unknown",
    "AREA": "World",
    "BBOX": { "-90": { "-180": { "90": 180 } } }
  },
  "ID": { "EPSG": 4326 },
  "projName": "longlat",
  "datumCode": "wgs84",
  "srsCode": "WGS 84"
}
```