### PR TITLE
Fix axis calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function cleanWKT(wkt) {
     var axisOrder = '';
     for (var i = 0, ii = wkt.AXIS.length; i < ii; ++i) {
       var axis = wkt.AXIS[i];
-      var descriptor = axis[0].toLowerCase();
+      var descriptor = axis[1].toLowerCase();
       if (descriptor.indexOf('north') !== -1) {
         axisOrder += 'n';
       } else if (descriptor.indexOf('south') !== -1) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "wkt.build.js",
   "module": "index.js",
   "scripts": {
-    "test": "node test.js",
+    "test": "node -r esm test.js",
     "build": "rollup -c",
     "pretest": "npm run build"
   },
@@ -32,6 +32,8 @@
   },
   "homepage": "https://github.com/proj4js/wkt-parser#readme",
   "devDependencies": {
+    "esm": "^3.2.25",
+    "js-struct-compare": "^1.1.0",
     "rollup": "^0.41.4",
     "tape": "^4.6.3"
   }

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -1,117 +1,5 @@
 [{
   "code": "PROJCS[\"NZGD49 / New Zealand Map Grid\",GEOGCS[\"NZGD49\",DATUM[\"New_Zealand_Geodetic_Datum_1949\",SPHEROID[\"International 1924\",6378388,297,AUTHORITY[\"EPSG\",\"7022\"]],TOWGS84[59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993],AUTHORITY[\"EPSG\",\"6272\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4272\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"New_Zealand_Map_Grid\"],PARAMETER[\"latitude_of_origin\",-41],PARAMETER[\"central_meridian\",173],PARAMETER[\"false_easting\",2510000],PARAMETER[\"false_northing\",6023150],AUTHORITY[\"EPSG\",\"27200\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
-  "intermediate": [
-  "PROJCS",
-  "NZGD49 / New Zealand Map Grid",
-  [
-    "GEOGCS",
-    "NZGD49",
-    [
-      "DATUM",
-      "New_Zealand_Geodetic_Datum_1949",
-      [
-        "SPHEROID",
-        "International 1924",
-        6378388,
-        297,
-        [
-          "AUTHORITY",
-          "EPSG",
-          "7022"
-        ]
-      ],
-      [
-        "TOWGS84",
-        59.47,
-        -5.04,
-        187.44,
-        0.47,
-        -0.1,
-        1.024,
-        -4.5993
-      ],
-      [
-        "AUTHORITY",
-        "EPSG",
-        "6272"
-      ]
-    ],
-    [
-      "PRIMEM",
-      "Greenwich",
-      0,
-      [
-        "AUTHORITY",
-        "EPSG",
-        "8901"
-      ]
-    ],
-    [
-      "UNIT",
-      "degree",
-      0.01745329251994328,
-      [
-        "AUTHORITY",
-        "EPSG",
-        "9122"
-      ]
-    ],
-    [
-      "AUTHORITY",
-      "EPSG",
-      "4272"
-    ]
-  ],
-  [
-    "UNIT",
-    "metre",
-    1,
-    [
-      "AUTHORITY",
-      "EPSG",
-      "9001"
-    ]
-  ],
-  [
-    "PROJECTION",
-    "New_Zealand_Map_Grid"
-  ],
-  [
-    "PARAMETER",
-    "latitude_of_origin",
-    -41
-  ],
-  [
-    "PARAMETER",
-    "central_meridian",
-    173
-  ],
-  [
-    "PARAMETER",
-    "false_easting",
-    2510000
-  ],
-  [
-    "PARAMETER",
-    "false_northing",
-    6023150
-  ],
-  [
-    "AUTHORITY",
-    "EPSG",
-    "27200"
-  ],
-  [
-    "AXIS",
-    "Easting",
-    "EAST"
-  ],
-  [
-    "AXIS",
-    "Northing",
-    "NORTH"
-  ]
-],
   "value": {
     "type": "PROJCS",
     "name": "NZGD49 / New Zealand Map Grid",
@@ -123,11 +11,9 @@
           "name": "International 1924",
           "a": 6378388,
           "rf": 297,
-          "auth": [
-            "AUTHORITY",
-            "EPSG",
-            "7022"
-          ]
+          "AUTHORITY": {
+            "EPSG": "7022"
+          }
         },
         "TOWGS84": [
           59.47, -5.04,
@@ -142,20 +28,16 @@
       "PRIMEM": {
         "name": "greenwich",
         "convert": 0,
-        "auth": [
-          "AUTHORITY",
-          "EPSG",
-          "8901"
-        ]
+        "AUTHORITY": {
+          "EPSG": "8901"
+        }
       },
       "UNIT": {
         "name": "degree",
         "convert": 0.01745329251994328,
-        "auth": [
-          "AUTHORITY",
-          "EPSG",
-          "9122"
-        ]
+        "AUTHORITY": {
+          "EPSG": "9122"
+        }
       },
       "AUTHORITY": {
         "EPSG": "4272"
@@ -164,11 +46,9 @@
     "UNIT": {
       "name": "metre",
       "convert": 1,
-      "auth": [
-        "AUTHORITY",
-        "EPSG",
-        "9001"
-      ]
+      "AUTHORITY": {
+        "EPSG": "9001"
+      }
     },
     "PROJECTION": "New_Zealand_Map_Grid",
     "latitude_of_origin": -41,
@@ -178,13 +58,20 @@
     "AUTHORITY": {
       "EPSG": "27200"
     },
-    "AXIS": {
-      "Northing": "NORTH"
-    },
+    "AXIS": [
+      ["Easting", "EAST"],
+      ["Northing", "NORTH"]
+    ],
     "projName": "New_Zealand_Map_Grid",
     "units": "meter",
     "to_meter": 1,
     "datumCode": "nzgd49",
+    "datum_params": [
+        59.47, -5.04,
+      187.44,  0.47,
+        -0.1, 1.024,
+      -4.5993
+    ],
     "ellps": "intl",
     "a": 6378388,
     "rf": 297,
@@ -192,122 +79,11 @@
     "y0": 6023150,
     "long0": 3.01941960595019,
     "lat0": -0.7155849933176751,
+    "axis": "enu",
     "srsCode": "NZGD49 / New Zealand Map Grid"
   }
 }, {
   "code": "PROJCS[\"NAD83 / Massachusetts Mainland\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Lambert_Conformal_Conic_2SP\"],PARAMETER[\"standard_parallel_1\",42.68333333333333],PARAMETER[\"standard_parallel_2\",41.71666666666667],PARAMETER[\"latitude_of_origin\",41],PARAMETER[\"central_meridian\",-71.5],PARAMETER[\"false_easting\",200000],PARAMETER[\"false_northing\",750000],AUTHORITY[\"EPSG\",\"26986\"],AXIS[\"X\",EAST],AXIS[\"Y\",NORTH]]",
-  "intermediate":[
-  "PROJCS",
-  "NAD83 / Massachusetts Mainland",
-  [
-    "GEOGCS",
-    "NAD83",
-    [
-      "DATUM",
-      "North_American_Datum_1983",
-      [
-        "SPHEROID",
-        "GRS 1980",
-        6378137,
-        298.257222101,
-        [
-          "AUTHORITY",
-          "EPSG",
-          "7019"
-        ]
-      ],
-      [
-        "AUTHORITY",
-        "EPSG",
-        "6269"
-      ]
-    ],
-    [
-      "PRIMEM",
-      "Greenwich",
-      0,
-      [
-        "AUTHORITY",
-        "EPSG",
-        "8901"
-      ]
-    ],
-    [
-      "UNIT",
-      "degree",
-      0.01745329251994328,
-      [
-        "AUTHORITY",
-        "EPSG",
-        "9122"
-      ]
-    ],
-    [
-      "AUTHORITY",
-      "EPSG",
-      "4269"
-    ]
-  ],
-  [
-    "UNIT",
-    "metre",
-    1,
-    [
-      "AUTHORITY",
-      "EPSG",
-      "9001"
-    ]
-  ],
-  [
-    "PROJECTION",
-    "Lambert_Conformal_Conic_2SP"
-  ],
-  [
-    "PARAMETER",
-    "standard_parallel_1",
-    42.68333333333333
-  ],
-  [
-    "PARAMETER",
-    "standard_parallel_2",
-    41.71666666666667
-  ],
-  [
-    "PARAMETER",
-    "latitude_of_origin",
-    41
-  ],
-  [
-    "PARAMETER",
-    "central_meridian",
-    -71.5
-  ],
-  [
-    "PARAMETER",
-    "false_easting",
-    200000
-  ],
-  [
-    "PARAMETER",
-    "false_northing",
-    750000
-  ],
-  [
-    "AUTHORITY",
-    "EPSG",
-    "26986"
-  ],
-  [
-    "AXIS",
-    "X",
-    "EAST"
-  ],
-  [
-    "AXIS",
-    "Y",
-    "NORTH"
-  ]
-],
   "value": {
     "type": "PROJCS",
     "name": "NAD83 / Massachusetts Mainland",
@@ -319,11 +95,9 @@
           "name": "GRS 1980",
           "a": 6378137,
           "rf": 298.257222101,
-          "auth": [
-            "AUTHORITY",
-            "EPSG",
-            "7019"
-          ]
+          "AUTHORITY": {
+            "EPSG": "7019"
+          }
         },
         "AUTHORITY": {
           "EPSG": "6269"
@@ -332,20 +106,16 @@
       "PRIMEM": {
         "name": "greenwich",
         "convert": 0,
-        "auth": [
-          "AUTHORITY",
-          "EPSG",
-          "8901"
-        ]
+        "AUTHORITY": {
+          "EPSG": "8901"
+        }
       },
       "UNIT": {
         "name": "degree",
         "convert": 0.01745329251994328,
-        "auth": [
-          "AUTHORITY",
-          "EPSG",
-          "9122"
-        ]
+        "AUTHORITY": {
+          "EPSG": "9122"
+        }
       },
       "AUTHORITY": {
         "EPSG": "4269"
@@ -354,11 +124,9 @@
     "UNIT": {
       "name": "metre",
       "convert": 1,
-      "auth": [
-        "AUTHORITY",
-        "EPSG",
-        "9001"
-      ]
+      "AUTHORITY": {
+        "EPSG": "9001"
+      }
     },
     "PROJECTION": "Lambert_Conformal_Conic_2SP",
     "standard_parallel_1": 42.68333333333333,
@@ -370,9 +138,10 @@
     "AUTHORITY": {
       "EPSG": "26986"
     },
-    "AXIS": {
-      "Y": "NORTH"
-    },
+    "AXIS": [
+      ["X", "EAST"],
+      ["Y", "NORTH"]
+    ],
     "projName": "Lambert_Conformal_Conic_2SP",
     "units": "meter",
     "to_meter": 1,
@@ -386,6 +155,86 @@
     "lat0": 0.7155849933176751,
     "lat1": 0.7449647023929129,
     "lat2": 0.7280931862903012,
+    "axis": "enu",
     "srsCode": "NAD83 / Massachusetts Mainland"
+  }
+}, {
+  "code": "PROJCS[\"ETRS89 / ETRS-LAEA\",GEOGCS[\"ETRS89\",DATUM[\"European_Terrestrial_Reference_System_1989\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6258\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4258\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Lambert_Azimuthal_Equal_Area\"],PARAMETER[\"latitude_of_center\",52],PARAMETER[\"longitude_of_center\",10],PARAMETER[\"false_easting\",4321000],PARAMETER[\"false_northing\",3210000],AUTHORITY[\"EPSG\",\"3035\"],AXIS[\"X\",EAST],AXIS[\"Y\",NORTH]]",
+  "value": {
+    "type": "PROJCS",
+    "name": "ETRS89 / ETRS-LAEA",
+    "GEOGCS": {
+      "name": "ETRS89",
+      "DATUM": {
+        "name": "European_Terrestrial_Reference_System_1989",
+        "SPHEROID": {
+          "name": "GRS 1980",
+          "a": 6378137,
+          "rf": 298.257222101,
+          "AUTHORITY": {
+            "EPSG": "7019"
+          }
+        },
+        "AUTHORITY": {
+          "EPSG": "6258"
+        }
+      },
+      "PRIMEM": {
+        "name": "greenwich",
+        "convert": 0,
+        "AUTHORITY": {
+          "EPSG": "8901"
+        }
+      },
+      "UNIT": {
+        "name": "degree",
+        "convert": 0.01745329251994328,
+        "AUTHORITY": {
+          "EPSG": "9122"
+        }
+      },
+      "AUTHORITY": {
+        "EPSG": "4258"
+      }
+    },
+    "UNIT": {
+      "name": "metre",
+      "convert": 1,
+      "AUTHORITY": {
+        "EPSG": "9001"
+      }
+    },
+    "PROJECTION": "Lambert_Azimuthal_Equal_Area",
+    "latitude_of_center": 52,
+    "longitude_of_center": 10,
+    "false_easting": 4321000,
+    "false_northing": 3210000,
+    "AUTHORITY": {
+      "EPSG": "3035"
+    },
+    "AXIS": [
+      [
+        "X",
+        "EAST"
+      ],
+      [
+        "Y",
+        "NORTH"
+      ]
+    ],
+    "projName": "Lambert_Azimuthal_Equal_Area",
+    "axis": "enu",
+    "units": "meter",
+    "to_meter": 1,
+    "datumCode": "european_terrestrial_reference_system_1989",
+    "ellps": "GRS 1980",
+    "a": 6378137,
+    "rf": 298.257222101,
+    "lat0": 0.9075712110370514,
+    "longc": 0.17453292519943295,
+    "x0": 4321000,
+    "y0": 3210000,
+    "srsCode": "ETRS89 / ETRS-LAEA",
+    "long0": 0.17453292519943295
   }
 }]

--- a/test.js
+++ b/test.js
@@ -1,12 +1,14 @@
 var test = require('tape');
+import compare from 'js-struct-compare';
 var wktParser = require('./wkt.build.js');
-var fixtures = require('./test-fixtures');
+var fixtures = require('./test-fixtures.json');
 
 fixtures.forEach((item, i)=>{
   test(`fixture ${i}`, t=>{
     var out = wktParser(item.code);
-    //var out = parser(item.code);
-    console.log(JSON.stringify(out, false, 2));
+    //console.log(JSON.stringify(out, false, 2));
+    const diff = JSON.stringify(compare(item.value, out), null, 2);
+    t.equal(diff, '[]');
     t.end();
   });
 })

--- a/wkt.build.js
+++ b/wkt.build.js
@@ -313,7 +313,7 @@ function cleanWKT(wkt) {
     var axisOrder = '';
     for (var i = 0, ii = wkt.AXIS.length; i < ii; ++i) {
       var axis = wkt.AXIS[i];
-      var descriptor = axis[0].toLowerCase();
+      var descriptor = axis[1].toLowerCase();
       if (descriptor.indexOf('north') !== -1) {
         axisOrder += 'n';
       } else if (descriptor.indexOf('south') !== -1) {


### PR DESCRIPTION
This pull request fixes the axis calculation. We have to check the second axis array entry for 'north', 'east', 'south', 'west', not the first. The previous version worked by chance when axis entries came in like
```
AXIS["Easting",EAST],AXIS["Northing",NORTH]
```
because 'east' is a substring of 'easting' and 'north' is a substring of 'northing'. But it failed in all other cases, like
```
AXIS["X",EAST],AXIS["Y",NORTH]
```

This pull request also makes the tests functional.