### PR TITLE
Axis lat/lon descriptor

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,13 +36,13 @@ function cleanWKT(wkt) {
     var axisOrder = '';
     for (var i = 0, ii = wkt.AXIS.length; i < ii; ++i) {
       var axis = [wkt.AXIS[i][0].toLowerCase(), wkt.AXIS[i][1].toLowerCase()];
-      if (axis[0].indexOf('north') !== -1 || (axis[0] === 'y' && axis[1] === 'north')) {
+      if (axis[0].indexOf('north') !== -1 || ((axis[0] === 'y' || axis[0] === 'lat') && axis[1] === 'north')) {
         axisOrder += 'n';
-      } else if (axis[0].indexOf('south') !== -1 || (axis[0] === 'y' && axis[1] === 'south')) {
+      } else if (axis[0].indexOf('south') !== -1 || ((axis[0] === 'y' || axis[0] === 'lat') && axis[1] === 'south')) {
         axisOrder += 's';
-      } else if (axis[0].indexOf('east') !== -1 || (axis[0] === 'x' && axis[1] === 'east')) {
+      } else if (axis[0].indexOf('east') !== -1 || ((axis[0] === 'x' || axis[0] === 'lon') && axis[1] === 'east')) {
         axisOrder += 'e';
-      } else if (axis[0].indexOf('west') !== -1 || (axis[0] === 'x' && axis[1] === 'west')) {
+      } else if (axis[0].indexOf('west') !== -1 || ((axis[0] === 'x' || axis[0] === 'lon') && axis[1] === 'west')) {
         axisOrder += 'w';
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wkt-parser",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "wkt-parser ===",
   "main": "wkt.build.js",
   "module": "index.js",

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -237,4 +237,60 @@
     "srsCode": "ETRS89 / ETRS-LAEA",
     "long0": 0.17453292519943295
   }
+}, {
+  "code": "GEOGCS[\"ETRS89\",DATUM[\"European Terrestrial Reference System 1989 ensemble\",SPHEROID[\"GRS 1980\",6378137,298.2572221,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6258\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9102\"]],AXIS[\"Lat\",north],AXIS[\"Lon\",east],AUTHORITY[\"EPSG\",\"4258\"]]",
+  "value": {
+    "type": "GEOGCS",
+    "name": "ETRS89",
+    "DATUM": {
+      "name": "European Terrestrial Reference System 1989 ensemble",
+      "SPHEROID": {
+        "name": "GRS 1980",
+        "a": 6378137,
+        "rf": 298.2572221,
+        "AUTHORITY": {
+          "EPSG": "7019"
+        }
+      },
+      "AUTHORITY": {
+        "EPSG": "6258"
+      }
+    },
+    "PRIMEM": {
+      "name": "greenwich",
+      "convert": 0,
+      "AUTHORITY": {
+        "EPSG": "8901"
+      }
+    },
+    "UNIT": {
+      "name": "degree",
+      "convert": 0.0174532925199433,
+      "AUTHORITY": {
+        "EPSG": "9102"
+      }
+    },
+    "AXIS": [
+      [
+        "Lat",
+        "north"
+      ],
+      [
+        "Lon",
+        "east"
+      ]
+    ],
+    "AUTHORITY": {
+      "EPSG": "4258"
+    },
+    "projName": "longlat",
+    "units": "degree",
+    "to_meter": 111319.4907932736,
+    "datumCode": "european terrestrial reference system 1989 ensemble",
+    "ellps": "GRS 1980",
+    "a": 6378137,
+    "rf": 298.2572221,
+    "axis": "neu",
+    "srsCode": "ETRS89"
+  }
 }]

--- a/wkt.build.js
+++ b/wkt.build.js
@@ -313,13 +313,13 @@ function cleanWKT(wkt) {
     var axisOrder = '';
     for (var i = 0, ii = wkt.AXIS.length; i < ii; ++i) {
       var axis = [wkt.AXIS[i][0].toLowerCase(), wkt.AXIS[i][1].toLowerCase()];
-      if (axis[0].indexOf('north') !== -1 || (axis[0] === 'y' && axis[1] === 'north')) {
+      if (axis[0].indexOf('north') !== -1 || ((axis[0] === 'y' || axis[0] === 'lat') && axis[1] === 'north')) {
         axisOrder += 'n';
-      } else if (axis[0].indexOf('south') !== -1 || (axis[0] === 'y' && axis[1] === 'south')) {
+      } else if (axis[0].indexOf('south') !== -1 || ((axis[0] === 'y' || axis[0] === 'lat') && axis[1] === 'south')) {
         axisOrder += 's';
-      } else if (axis[0].indexOf('east') !== -1 || (axis[0] === 'x' && axis[1] === 'east')) {
+      } else if (axis[0].indexOf('east') !== -1 || ((axis[0] === 'x' || axis[0] === 'lon') && axis[1] === 'east')) {
         axisOrder += 'e';
-      } else if (axis[0].indexOf('west') !== -1 || (axis[0] === 'x' && axis[1] === 'west')) {
+      } else if (axis[0].indexOf('west') !== -1 || ((axis[0] === 'x' || axis[0] === 'lon') && axis[1] === 'west')) {
         axisOrder += 'w';
       }
     }


### PR DESCRIPTION
This pull request adds support for the Lat/Lon axis descriptor used on epsg.org, e.g.
```
AXIS["Lat",north],AXIS["Lon",east]
```