### PR TITLE
Add limitations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ wkt-parser
 ===
 
 The wkt parser pulled out of proj4 so it can be hacked on.
+
+The parser currently only supports wkt strings of [version 1](https://docs.ogc.org/is/18-010r7/18-010r7.html#196) (earlier than 2015).
+
+It does not support geocentric currently (`GEOCCS`).


### PR DESCRIPTION
This adds some documentation about the wkt strings that can be parsed, based on [this comment](https://github.com/proj4js/proj4js/issues/470#issuecomment-2159070598) about geocentric projection, and[ this comment](https://github.com/proj4js/proj4js/issues/393#issuecomment-890492588) about the wkt version.

