### PR TITLE
add ProjectionDefinition.title from wkt.AUTHORITY

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ function d2r(input) {
 }
 
 function cleanWKT(wkt) {
+  if (wkt.AUTHORITY) {
+    var authority = Object.keys(wkt.AUTHORITY)[0];
+    if (authority && authority in wkt.AUTHORITY) {
+      wkt.title = `${authority}:${wkt.AUTHORITY[authority]}`;
+    }
+  }
   if (wkt.type === 'GEOGCS') {
     wkt.projName = 'longlat';
   } else if (wkt.type === 'LOCAL_CS') {

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -62,6 +62,7 @@
       ["Easting", "EAST"],
       ["Northing", "NORTH"]
     ],
+    "title": "EPSG:27200",
     "projName": "New_Zealand_Map_Grid",
     "units": "meter",
     "to_meter": 1,
@@ -142,6 +143,7 @@
       ["X", "EAST"],
       ["Y", "NORTH"]
     ],
+    "title": "EPSG:26986",
     "projName": "Lambert_Conformal_Conic_2SP",
     "units": "meter",
     "to_meter": 1,
@@ -222,6 +224,7 @@
         "NORTH"
       ]
     ],
+    "title": "EPSG:3035",
     "projName": "Lambert_Azimuthal_Equal_Area",
     "axis": "enu",
     "units": "meter",
@@ -283,6 +286,7 @@
     "AUTHORITY": {
       "EPSG": "4258"
     },
+    "title": "EPSG:4258",
     "projName": "longlat",
     "units": "degree",
     "to_meter": 111319.4907932736,
@@ -454,6 +458,7 @@
         "UNKNOWN"
       ]
     ],
+    "title": "EPSG:3031",
     "projName": "Polar_Stereographic",
     "axis": "enu",
     "units": "meter",


### PR DESCRIPTION
Following the DefinitelyTyped/types/proj4 (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/72db0783554789ef424e5dc5a207a028c2a0169f/types/proj4/index.d.ts)
title in ProjectionDefinition should be mandatory but is nowhere to be found in index.cleanWKT().
I just added the fact that in cas ther is an AUTHORITY defined in the wkt that we use this information as title (parsed as a string).


In case i'm not posting in the right place, or i'm not following the way it should be, fell free to tell me where and what I should do.

Thanks