### PR TITLE
Parse sub crs

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,21 @@ function d2r(input) {
 }
 
 function cleanWKT(wkt) {
+  var keys = Object.keys(wkt);
+  keys.forEach(key => {
+    // the followings are the crs defined in
+    // https://github.com/proj4js/proj4js/blob/1da4ed0b865d0fcb51c136090569210cdcc9019e/lib/parseCode.js#L11
+    if (['PROJECTEDCRS', 'PROJCRS', 'GEOGCS', 'GEOCCS', 'PROJCS', 'LOCAL_CS', 'GEODCRS',
+      'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'].includes(key)) {
+        setPropertiesFromWkt(wkt[key]);
+    };
+    if (typeof wkt[key] === 'object') {
+      cleanWKT(wkt[key]);
+    }
+  });
+}
+
+function setPropertiesFromWkt(wkt) {
   if (wkt.AUTHORITY) {
     var authority = Object.keys(wkt.AUTHORITY)[0];
     if (authority && authority in wkt.AUTHORITY) {
@@ -200,12 +215,9 @@ function cleanWKT(wkt) {
 }
 export default function(wkt) {
   var lisp = parser(wkt);
-  var type = lisp.shift();
-  var name = lisp.shift();
-  lisp.unshift(['name', name]);
-  lisp.unshift(['type', type]);
+  var type = lisp[0];
   var obj = {};
   sExpr(lisp, obj);
   cleanWKT(obj);
-  return obj;
+  return obj[type];
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var D2R = 0.01745329251994329577;
 import parser from './parser';
 import {sExpr} from './process';
 
-
+var knownTypes = ['PROJECTEDCRS', 'PROJCRS', 'GEOGCS', 'GEOCCS', 'PROJCS', 'LOCAL_CS', 'GEODCRS',
+  'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'];
 
 function rename(obj, params) {
   var outName = params[0];
@@ -21,24 +22,24 @@ function d2r(input) {
 
 function cleanWKT(wkt) {
   var keys = Object.keys(wkt);
-  keys.forEach(key => {
+  for (var i = 0, ii = keys.length; i <ii; ++i) {
+    var key = keys[i];
     // the followings are the crs defined in
     // https://github.com/proj4js/proj4js/blob/1da4ed0b865d0fcb51c136090569210cdcc9019e/lib/parseCode.js#L11
-    if (['PROJECTEDCRS', 'PROJCRS', 'GEOGCS', 'GEOCCS', 'PROJCS', 'LOCAL_CS', 'GEODCRS',
-      'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'].includes(key)) {
-        setPropertiesFromWkt(wkt[key]);
-    };
+    if (knownTypes.indexOf(key) !== -1) {
+      setPropertiesFromWkt(wkt[key]);
+    }
     if (typeof wkt[key] === 'object') {
       cleanWKT(wkt[key]);
     }
-  });
+  }
 }
 
 function setPropertiesFromWkt(wkt) {
   if (wkt.AUTHORITY) {
     var authority = Object.keys(wkt.AUTHORITY)[0];
     if (authority && authority in wkt.AUTHORITY) {
-      wkt.title = `${authority}:${wkt.AUTHORITY[authority]}`;
+      wkt.title = authority + ':' + wkt.AUTHORITY[authority];
     }
   }
   if (wkt.type === 'GEOGCS') {

--- a/process.js
+++ b/process.js
@@ -77,6 +77,21 @@ export function sExpr(v, obj) {
         sExpr(v[3], obj[key]);
       }
       return;
+    case 'EDATUM':
+    case 'ENGINEERINGDATUM':
+    case 'LOCAL_DATUM':
+    case 'DATUM':
+    case 'VERT_CS':
+    case 'VERTCRS':
+    case 'VERTICALCRS':
+      v[0] = ['name', v[0]];
+      mapit(obj, key, v);
+      return;
+    case 'COMPD_CS':
+    case 'COMPOUNDCRS':
+    case 'FITTED_CS':
+    // the followings are the crs defined in
+    // https://github.com/proj4js/proj4js/blob/1da4ed0b865d0fcb51c136090569210cdcc9019e/lib/parseCode.js#L11
     case 'PROJECTEDCRS':
     case 'PROJCRS':
     case 'GEOGCS':
@@ -86,20 +101,11 @@ export function sExpr(v, obj) {
     case 'GEODCRS':
     case 'GEODETICCRS':
     case 'GEODETICDATUM':
-    case 'EDATUM':
-    case 'ENGINEERINGDATUM':
-    case 'VERT_CS':
-    case 'VERTCRS':
-    case 'VERTICALCRS':
-    case 'COMPD_CS':
-    case 'COMPOUNDCRS':
-    case 'ENGINEERINGCRS':
     case 'ENGCRS':
-    case 'FITTED_CS':
-    case 'LOCAL_DATUM':
-    case 'DATUM':
+    case 'ENGINEERINGCRS':
       v[0] = ['name', v[0]];
       mapit(obj, key, v);
+      obj[key].type = key;
       return;
     default:
       i = -1;

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -4,6 +4,7 @@
     "type": "PROJCS",
     "name": "NZGD49 / New Zealand Map Grid",
     "GEOGCS": {
+      "type": "GEOGCS",
       "name": "NZGD49",
       "DATUM": {
         "name": "New_Zealand_Geodetic_Datum_1949",
@@ -41,7 +42,25 @@
       },
       "AUTHORITY": {
         "EPSG": "4272"
-      }
+      },
+      "title": "EPSG:4272",
+      "projName": "longlat",
+      "units": "degree",
+      "to_meter": 111323.87156969598,
+      "datumCode": "nzgd49",
+      "ellps": "intl",
+      "a": 6378388,
+      "rf": 297,
+      "datum_params": [
+        59.47,
+        -5.04,
+        187.44,
+        0.47,
+        -0.1,
+        1.024,
+        -4.5993
+      ],
+      "srsCode": "NZGD49"
     },
     "UNIT": {
       "name": "metre",
@@ -89,6 +108,7 @@
     "type": "PROJCS",
     "name": "NAD83 / Massachusetts Mainland",
     "GEOGCS": {
+      "type": "GEOGCS",
       "name": "NAD83",
       "DATUM": {
         "name": "North_American_Datum_1983",
@@ -120,7 +140,16 @@
       },
       "AUTHORITY": {
         "EPSG": "4269"
-      }
+      },
+      "title": "EPSG:4269",
+      "projName": "longlat",
+      "units": "degree",
+      "to_meter": 111319.49079327348,
+      "datumCode": "north_american_datum_1983",
+      "ellps": "GRS 1980",
+      "a": 6378137,
+      "rf": 298.257222101,
+      "srsCode": "NAD83"
     },
     "UNIT": {
       "name": "metre",
@@ -166,6 +195,7 @@
     "type": "PROJCS",
     "name": "ETRS89 / ETRS-LAEA",
     "GEOGCS": {
+      "type": "GEOGCS",
       "name": "ETRS89",
       "DATUM": {
         "name": "European_Terrestrial_Reference_System_1989",
@@ -197,7 +227,17 @@
       },
       "AUTHORITY": {
         "EPSG": "4258"
-      }
+      },
+      "title": "EPSG:4258",
+      "projName": "longlat",
+      "units": "degree",
+      "to_meter": 111319.49079327348,
+      "datumCode": "european_terrestrial_reference_system_1989",
+      "ellps": "GRS 1980",
+      "a": 6378137,
+      "rf": 298.257222101,
+      "srsCode": "ETRS89"
+
     },
     "UNIT": {
       "name": "metre",
@@ -304,8 +344,10 @@
     "type": "COMPD_CS",
     "name": "unknown",
     "PROJCS": {
+      "type": "PROJCS",
       "name": "NAD83 / Texas North Central",
       "GEOGCS": {
+        "type": "GEOGCS",
         "name": "NAD83",
         "DATUM": {
           "name": "North_American_Datum_1983",
@@ -334,7 +376,16 @@
         },
         "AUTHORITY": {
           "EPSG": "4269"
-        }
+        },
+        "title": "EPSG:4269",
+        "projName": "longlat",
+        "units": "degree",
+        "to_meter": 111319.4907932736,
+        "datumCode": "north_american_datum_1983",
+        "ellps": "GRS 1980",
+        "a": 6378137,
+        "rf": 298.257222101004,
+        "srsCode": "NAD83"
       },
       "PROJECTION": "Lambert_Conformal_Conic_2SP",
       "latitude_of_origin": 31.6666666666667,
@@ -362,7 +413,23 @@
       ],
       "AUTHORITY": {
         "EPSG": "32138"
-      }
+      },
+      "title": "EPSG:32138",
+      "projName": "Lambert_Conformal_Conic_2SP",
+      "axis": "enu",
+      "units": "us survey foot",
+      "to_meter": 0.304800609601219,
+      "datumCode": "north_american_datum_1983",
+      "ellps": "GRS 1980",
+      "a": 6378137,
+      "rf": 298.257222101004,
+      "x0": 599999.9999999997,
+      "y0": 1999999.9999999998,
+      "long0": -1.7191493132144147,
+      "lat0": 0.5526875964648716,
+      "lat1": 0.5608324663075106,
+      "lat2": 0.5928301692607412,
+      "srsCode": "NAD83 / Texas North Central"
     },
     "VERT_CS": {
       "name": "NAVD88 height (ftUS)",
@@ -389,8 +456,7 @@
       "AUTHORITY": {
         "EPSG": "6360"
       }
-    },
-    "srsCode": "unknown"
+    }
   }
 },
 {
@@ -399,6 +465,7 @@
     "type": "PROJCS",
     "name": "WGS 84 / Antarctic Polar Stereographic",
     "GEOGCS": {
+      "type": "GEOGCS",
       "name": "WGS 84",
       "DATUM": {
         "name": "WGS_1984",
@@ -430,7 +497,16 @@
       },
       "AUTHORITY": {
         "EPSG": "4326"
-      }
+      },
+      "title": "EPSG:4326",
+      "projName": "longlat",
+      "units": "degree",
+      "to_meter": 111319.49079327348,
+      "datumCode": "wgs84",
+      "ellps": "WGS 84",
+      "a": 6378137,
+      "rf": 298.257223563,
+      "srsCode": "WGS 84"
     },
     "UNIT": {
       "name": "metre",


### PR DESCRIPTION
Most Crs are based on other crs. (ie PROJC use GEOCRS)
In this PR I propose to treat each sub crs as a CRS to not only parse the main crs but laso the subcrs.

The idea behind this would be in case of COMP_CS to be able to directly extract the sub crs (usually the PROJCS and the VERT_CS) instead of spliting the string wk.