### PR TITLE
Less datum code modifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function setPropertiesFromWkt(wkt) {
     if (wkt.datumCode.slice(0, 2) === 'd_') {
       wkt.datumCode = wkt.datumCode.slice(2);
     }
-    if (wkt.datumCode === 'new_zealand_geodetic_datum_1949' || wkt.datumCode === 'new_zealand_1949') {
+    if (wkt.datumCode === 'new_zealand_1949') {
       wkt.datumCode = 'nzgd49';
     }
     if (wkt.datumCode === 'wgs_1984' || wkt.datumCode === 'world_geodetic_system_1984') {
@@ -115,13 +115,7 @@ function setPropertiesFromWkt(wkt) {
       }
       wkt.datumCode = 'wgs84';
     }
-    if (wkt.datumCode.slice(-6) === '_ferro') {
-      wkt.datumCode = wkt.datumCode.slice(0, - 6);
-    }
-    if (wkt.datumCode.slice(-8) === '_jakarta') {
-      wkt.datumCode = wkt.datumCode.slice(0, - 8);
-    }
-    if (~wkt.datumCode.indexOf('belge')) {
+    if (wkt.datumCode === 'belge_1972') {
       wkt.datumCode = 'rnb72';
     }
     if (geogcs.DATUM && geogcs.DATUM.SPHEROID) {

--- a/test-fixtures.json
+++ b/test-fixtures.json
@@ -47,7 +47,7 @@
       "projName": "longlat",
       "units": "degree",
       "to_meter": 111323.87156969598,
-      "datumCode": "nzgd49",
+      "datumCode": "new_zealand_geodetic_datum_1949",
       "ellps": "intl",
       "a": 6378388,
       "rf": 297,
@@ -85,7 +85,7 @@
     "projName": "New_Zealand_Map_Grid",
     "units": "meter",
     "to_meter": 1,
-    "datumCode": "nzgd49",
+    "datumCode": "new_zealand_geodetic_datum_1949",
     "datum_params": [
         59.47, -5.04,
       187.44,  0.47,


### PR DESCRIPTION
With v2.14.0, proj4 works with OGC WKT v1 datum codes by default. So many of the tweaks on datum codes here are no longer necessary.